### PR TITLE
Hotfix/17 access token cookie save fix

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  reactStrictMode: false,
   webpack: (config, { isServer }) => {
     if (!isServer) {
       config.resolve.fallback.fs = isServer;

--- a/src/app/users/_containers/SocialSignIn.tsx
+++ b/src/app/users/_containers/SocialSignIn.tsx
@@ -1,8 +1,6 @@
 'use client';
-import api from '@/app/api';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
-import React from 'react';
 
 type signInProps = {
   title: string;

--- a/src/app/users/kakao/callback/page.tsx
+++ b/src/app/users/kakao/callback/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 import api from '@/app/api';
 import useAuth from '@/contexts/auth.context';
-import { useQuery } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 
@@ -16,7 +15,7 @@ const KakaoCallbackPage = ({
 
   useEffect(() => {
     const signInAndRedirect = async () => {
-      await `${process.env.NEXT_PUBLIC_SERVER_URL}/users/kakao/callback?code=${code}`;
+      await api.auth.signInKakao(code);
       signIn();
       router.push('/');
     };


### PR DESCRIPTION
이슈번호: #17 

작업 상세
1. fix: 클라이언트 측 쿠키 저장 문제 해결
  - Kakao 로그인 콜백 URL을 API 호출하도록 수정
2. fix: 카카오 콜백 api 호출 에러 해결
  - 2번 렌더링시 카카오 콜백 api 호출 에러 발생 -> strict 모드 비활성화

