### PR TITLE
fix: 방명록 링크 생성 페이지 잘림 현상 수정

### DIFF
--- a/src/app/guest-book/link/_container/ImageUploadContainer.tsx
+++ b/src/app/guest-book/link/_container/ImageUploadContainer.tsx
@@ -48,6 +48,7 @@ function ImageUploadContainer({
       className={clsx(
         'row-start-3',
         'row-span-8',
+        'my-7',
         `justify-${file ? 'start' : 'center'}`,
       )}
       background={file ? 'paper' : 'none'}

--- a/src/app/guest-book/link/page.tsx
+++ b/src/app/guest-book/link/page.tsx
@@ -6,9 +6,9 @@ import * as htmlToImage from 'html-to-image';
 import { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime';
 import { useRouter } from 'next/navigation';
 import { ChangeEvent, useState } from 'react';
+import InputWithLabel from '../../../components/InputWithLabel';
 import ButtonContainer from '../_containers/ButtonContainer';
 import ImageUploadContainer from './_container/ImageUploadContainer';
-import InputWithLabel from '../../../components/InputWithLabel';
 
 const handleVisitorNameInput = (
   e: ChangeEvent<HTMLInputElement>,
@@ -47,13 +47,13 @@ function NewGuestBookLink() {
       : undefined;
 
   return (
-    <Grid className='px-10 grid-rows-12 min-h-dvh'>
+    <Grid className='w-full h-full grid-cols-1 px-10 grid-rows-12'>
       <InputWithLabel
         id='visitor-name'
         labelText={labelText}
         placeholder='방문자 이름을 입력해주세요'
         value={visitor}
-        classNameFlex='justify-end row-span-2 row-start-1 mb-7'
+        classNameFlex='justify-end row-span-1 row-start-2'
         classNameLabel='w-full'
         onChange={(e) => handleVisitorNameInput(e, setVisitor)}
       />


### PR DESCRIPTION
이슈번호
- #24 

원인?
- Grid 컴포넌트는 기본적으로 자식 컴포넌트들을 가로로 배치하려고 했겠지만, 자식 컴포넌트들의 가로 너비 합이 Grid의 가로 너비보다 클 경우, 컴포넌트들이 잘려서 보이는 문제가 발생했을 수 있음

해결
- grid-cols-1을 설정함으로써 Grid는 명시적으로 1개의 열로 구성되었고, 자식 컴포넌트들은 세로로 쌓이게 설정됨
- 각 컴포넌트는 전체 가로 너비를 차지할 수 있게 되었고, 잘림 현상이 해결된 것으로 보임

수정 전
- ![image](https://github.com/HomeLog/homelog-client/assets/30682847/db5824c1-4b5e-42c2-b044-e32620e43e7a)

수정 후
- ![image](https://github.com/HomeLog/homelog-client/assets/30682847/aa675fd2-b6d5-4e86-b770-2a5c50643d54)
