### PR TITLE
chore: 홈 이미지에 필터 적용

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -53,6 +53,10 @@ export default function Home() {
             objectFit='cover'
             className='w-full'
           />
+          <div
+            id='filter'
+            className='absolute inset-0 bg-black opacity-40 flex items-center justify-center'
+          />
         </div>
         <Flex className='absolute w-full h-full'>
           <div

--- a/src/app/profile/_containers/ProfileImages.tsx
+++ b/src/app/profile/_containers/ProfileImages.tsx
@@ -76,6 +76,10 @@ function ProfileImages({
               objectFit='cover'
               className='w-full'
             />
+            <div
+              id='filter'
+              className='absolute inset-0 bg-black opacity-40 flex items-center justify-center'
+            />
           </Button>
         </div>
         <div className='absolute bg-inherit aspect-square w-[14%]'>

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -8,7 +8,7 @@ const buttonVariants = cva('', {
       primary: 'bg-[#DADADA] text-white hover:bg-[#999999]',
       secondary: 'bg-white text-black hover:bg-[#999999]/10',
       transparent:
-        'bg-white/30 text-white hover:bg-[#999999] hover:bg-[#999999]/50',
+        'bg-white/40 text-white hover:bg-[#999999] hover:bg-[#999999]/50',
       none: '',
     },
     size: {


### PR DESCRIPTION
- 홈 및 프로필 편집 페이지에서 홈 이미지에 필터 적용
  - 방명록 이름, 총 방명록 수, 버튼이 더욱 잘보이게 하기 위함

전
<img width="250" alt="전" src="https://github.com/HomeLog/homelog-client/assets/108922813/63bee84e-5763-4509-9d29-4cace55fc623">
후
<img width="250" alt="후" src="https://github.com/HomeLog/homelog-client/assets/108922813/a7b4752b-fd85-4e3a-9e8a-6376ff70bfd1">
