### PR TITLE
fix: 홈페이지 ui 버그 수정

### DIFF
--- a/src/app/_components/Polaroid.tsx
+++ b/src/app/_components/Polaroid.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
-import Image from 'next/image';
-import Button from '@/components/Button';
-import { useRouter } from 'next/navigation';
 import { DGuestBook } from '@/types/guestbook.type';
+import Image from 'next/image';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 
 function Polaroid(guestbook: DGuestBook) {
   let thumbnail = '/images/background.png';
@@ -15,19 +14,16 @@ function Polaroid(guestbook: DGuestBook) {
   };
 
   return (
-    <Button
-      className='bg-white w-[90%] h-40 drop-shadow-md rounded-sm p-0 mx-auto mb-5'
-      onClick={redirectToGuestbookDetailPage}
-    >
-      <div className='relative w-[90%] h-[75%] mx-auto mb-[10%] bg-black overflow-hidden'>
+    <div className='w-[90%] aspect-2/3 drop-shadow-md rounded-sm overflow-hidden p-0 mx-auto mb-5'>
+      <Link href={link}>
         <Image
           src={thumbnail}
           alt='guestbook thumbnail'
           layout='fill'
           objectFit='cover'
         />
-      </div>
-    </Button>
+      </Link>
+    </div>
   );
 }
 


### PR DESCRIPTION
작업 상세
*  홈화면에서 이미지 로드시 회색 공백이 생기는 현상 수정
* before

<img width="175" alt="image" src="https://github.com/HomeLog/homelog-client/assets/30682847/fb953178-a689-44bb-8f57-3d9f1b57e77e">

* after

<img width="1097" alt="image" src="https://github.com/HomeLog/homelog-client/assets/30682847/9140a2bb-f927-4225-8702-73caa906a668">


