### PR TITLE
통합 테스트를 위한 도커파일 구성과 이미지 도메인 추가

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,38 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+.yarn/install-state.gz
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env*.local
+.env
+.env*
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_API_IMAGE_SERVER_URL=http://homelog-storage:9000/homelog
+NEXT_PUBLIC_SERVER_URL=http://localhost:3001

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,10 @@
+FROM node:22-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+
+CMD ["npm", "run", "dev"]

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,6 +9,12 @@ const nextConfig = {
         port: '',
         pathname: '/**',
       },
+      {
+        protocol: 'http',
+        hostname: 'homelog-storage',
+        port: '9000',
+        pathname: '/**',
+      },
     ],
   },
   webpack: (config, { isServer }) => {


### PR DESCRIPTION
이슈 번호
- #54  

작업 상세
- .env.test 파일 추가
  - NEXT_PUBLIC_API_IMAGE_SERVER_URL 설정
  - NEXT_PUBLIC_SERVER_URL 설정
- next.config.mjs 파일 수정
  - 테스트용 Minio 서버 도메인(homelog-storage:9000) 이미지 허용 목록에 추가
- .dockerignore 파일 추가
  - Docker 이미지 빌드 시 불필요한 파일 제외 설정