### PR TITLE
fix: 이미지 생성 속도 개선

### DIFF
--- a/src/app/guest-book/_utils/image.util.ts
+++ b/src/app/guest-book/_utils/image.util.ts
@@ -12,9 +12,9 @@ export const processImage = async () => {
 const buildJpeg = async (elementId: string) => {
   const element = document.getElementById(elementId) as HTMLElement;
   let dataUrl = '';
-  const minDataLength = 2000000;
+  const minDataLength = 1000000;
   let i = 0;
-  const maxAttempts = 10;
+  const maxAttempts = 5;
 
   while (dataUrl.length < minDataLength && i < maxAttempts) {
     dataUrl = await htmlToImage.toJpeg(element, {


### PR DESCRIPTION
이슈 번호
- #59 

작업 상세
- 링크 생성 속도가 너무 느렸는데 이미지 생성 속도가 느렸기 때문임
- 아래 코드에서 minDataLength를 1000000으로 변경 및 maxAttempts를 5로 변경
```ts
const buildJpeg = async (elementId: string) => {
  const element = document.getElementById(elementId) as HTMLElement;
  let dataUrl = '';
  const minDataLength = 2000000;
  let i = 0;
  const maxAttempts = 10;

  while (dataUrl.length < minDataLength && i < maxAttempts) {
    dataUrl = await htmlToImage.toJpeg(element, {
      quality: 1,
    });
    i += 1;
  }

  return dataUrl;
};
```