### PR TITLE
fix: 방명록 남기기 페이지 로그인 요구 비활성화

### DIFF
--- a/src/app/guest-book/[id]/page.tsx
+++ b/src/app/guest-book/[id]/page.tsx
@@ -5,12 +5,9 @@ import Flex from '@/components/Flex';
 import Grid from '@/components/Grid';
 import useAuth from '@/contexts/auth.context';
 import { useEnvVariablesClientConfig } from '@/contexts/envVariablesClient.context';
-import { showToast } from '@/libs/utils';
 import { useQuery } from '@tanstack/react-query';
 import clsx from 'clsx';
 import Image from 'next/image';
-import { useRouter } from 'next/navigation';
-import { useEffect } from 'react';
 import ContentsCaption from '../_containers/ContentsCaption';
 import ContentsInfo from '../_containers/ContentsInfo';
 import ImageBackgroundWrapper from '../_containers/ImageBackgroundWrapper';
@@ -19,15 +16,6 @@ import MenuBar from '../_containers/MenuBar';
 function DetailsPage({ params }: { params: { id: string } }) {
   const { loading, signedIn } = useAuth();
   const config = useEnvVariablesClientConfig();
-
-  const router = useRouter();
-
-  useEffect(() => {
-    if (loading === false && signedIn === false) {
-      showToast.error('로그인이 필요합니다.');
-      router.push('/users');
-    }
-  }, [loading, signedIn, router]);
 
   const { data } = useQuery({
     queryKey: ['guestbook'],
@@ -68,7 +56,9 @@ function DetailsPage({ params }: { params: { id: string } }) {
             caption={data.content as string}
           />
         </Flex>
-        <MenuBar className='h-full row-span-1 row-start-12' id={params.id} />
+        {!loading && signedIn && (
+          <MenuBar className='h-full row-span-1 row-start-12' id={params.id} />
+        )}
       </Grid>
     )
   );

--- a/src/app/guest-book/create/_hook/useGuestBookLink.ts
+++ b/src/app/guest-book/create/_hook/useGuestBookLink.ts
@@ -1,13 +1,11 @@
 import api from '@/api';
-import useAuth from '@/contexts/auth.context';
 import { showToast } from '@/libs/utils';
 import TImageFile from '@/types/image.file';
 import { useMutation } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 const useGuestBookLink = () => {
-  const { signedIn, loading } = useAuth();
   const [visitorName, setVisitorName] = useState('');
   const [file, setFile] = useState<TImageFile | null>(null);
   const router = useRouter();
@@ -37,13 +35,6 @@ const useGuestBookLink = () => {
       showToast.error('방명록 링크 생성이 실패했습니다.');
     },
   });
-
-  useEffect(() => {
-    if (!signedIn && !loading) {
-      showToast.error('로그인 후 이용해주세요!');
-      router.push('/users');
-    }
-  }, [signedIn, router, loading]);
 
   return { visitorName, setVisitorName, file, setFile, createLink };
 };

--- a/src/app/guest-book/create/page.tsx
+++ b/src/app/guest-book/create/page.tsx
@@ -2,6 +2,10 @@
 
 import Grid from '@/components/Grid';
 import InputWithLabel from '@/components/InputWithLabel';
+import useAuth from '@/contexts/auth.context';
+import { showToast } from '@/libs/utils';
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
 import ButtonContainer from '../_containers/ButtonContainer';
 import {
   handleVisitorNameInput,
@@ -10,11 +14,20 @@ import {
 } from '../_utils/form.util';
 import ImageUploadContainer from './_container/ImageUploadContainer';
 import useGuestBookLink from './_hook/useGuestBookLink';
-import { showToast } from '@/libs/utils';
 
 export default function GuestbookCreatePage() {
   const { visitorName, setVisitorName, file, setFile, createLink } =
     useGuestBookLink();
+
+  const { signedIn, loading } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!signedIn && !loading) {
+      showToast.error('로그인 후 이용해주세요!');
+      router.push('/users');
+    }
+  }, [signedIn, router, loading]);
 
   const handleButtonClick = async () => {
     if (!validateForm(visitorName, file)) return;


### PR DESCRIPTION
이슈 번호
- #74 

작업 상세
- 방명록 남기기 페이지 로그인 요구 비활성화
- 방명록을 남긴 다음 방문자는 상세 페이지를 볼 수 있음
  - 비회원은 메뉴바가 보이지 않음