### PR TITLE
리프레시 토큰 도입

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -6,6 +6,12 @@ const nextConfig = {
     remotePatterns: [
       {
         protocol: 'https',
+        hostname: 'homelog-dev.s3.ap-northeast-2.amazonaws.com',
+        port: '',
+        pathname: '/**',
+      },
+      {
+        protocol: 'https',
         hostname: 'homelog.s3.ap-northeast-2.amazonaws.com',
         port: '',
         pathname: '/**',

--- a/src/api/auth/auth.api.ts
+++ b/src/api/auth/auth.api.ts
@@ -32,3 +32,12 @@ export async function checkSignIn() {
 
   return response.data.result;
 }
+
+export async function refresh() {
+  const response = await client.get(`/users/refresh`, {
+    baseURL: window?.ENV?.NEXT_PUBLIC_SERVER_URL ?? client.defaults.baseURL,
+    withCredentials: true,
+  });
+
+  return response.data.result;
+}


### PR DESCRIPTION
작업 배경
- 현재 액세스 토큰의 유호 시간은 15분으로 상당히 짧은 편임
  - 유저가 재로그인을 자주 겪게 되며 불편 ⬆️⬆️

작업 상세
- 개발환경용 이미지 서버 추가
- 리프레시 토큰 도입
  - 액세스 토큰 갱신용 api 추가
   - 프로바이더 내부 액세스 토큰 재발급 로직 추가

기대 효과
- 리프레시 토큰 도입: 재로그인 횟수 감소(사용자 편의성 향상)
- 리프레시 토큰 로테이션 도입: 토큰 탈취 위험 완화
![로그인처리과정](https://github.com/user-attachments/assets/c3f68887-3b4c-4594-a872-a3310611c6cb)
![인증및인가과정](https://github.com/user-attachments/assets/72d7159f-3c0e-4e2b-8cb6-e643c0f43e8b)

